### PR TITLE
Add Myna evaluation configs and padding transform

### DIFF
--- a/configs/probe.Myna85M.Chords1217.yaml
+++ b/configs/probe.Myna85M.Chords1217.yaml
@@ -1,0 +1,179 @@
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.Chords1217.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.Chords1217.Myna85M"
+      save_dir: "./output/probe.Chords1217.Myna85M/"
+
+model:
+  class_path: marble.tasks.Chords1217.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 375
+          mode: nearest
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoderKeepTime
+        init_args:
+          in_dim: 1536
+          out_dim: 25
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: marble.tasks.Chords1217.probe.ChordCrossEntropyLoss
+        init_args:
+          time_dim_mismatch_tol: 5
+
+    metrics:
+      train:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      val:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      test:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+data:
+  class_path: marble.tasks.Chords1217.datamodule.Chords1217DataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/Chords1217/Chords1217.train.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    val:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.val.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    test:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.test.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.Myna85M.EMO.yaml
+++ b/configs/probe.Myna85M.EMO.yaml
@@ -1,0 +1,190 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.EMO.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/r2"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.EMO.Myna85M"
+      save_dir: "./output/probe.EMO.Myna85M/"
+
+model:
+  class_path: marble.tasks.EMO.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 2 # arousal, valence
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.MSELoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      val:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      test:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+
+data:
+  class_path: marble.tasks.EMO.datamodule.EMODataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/EMO/EMO.train.jsonl
+    val:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.val.jsonl
+    test:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/r2"

--- a/configs/probe.Myna85M.GS.yaml
+++ b/configs/probe.Myna85M.GS.yaml
@@ -1,0 +1,175 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GS.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GS.Myna85M"
+      save_dir: "./output/probe.GS.Myna85M/"
+
+model:
+  class_path: marble.tasks.GS.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 24 # 24 keys
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.GS.datamodule.GSDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GS.datamodule.GSAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GS/GS.train.jsonl
+    val:
+      class_path: marble.tasks.GS.datamodule.GSAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.val.jsonl
+    test:
+      class_path: marble.tasks.GS.datamodule.GSAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.Myna85M.GTZANBeatTracking.yaml
+++ b/configs/probe.Myna85M.GTZANBeatTracking.yaml
@@ -1,0 +1,220 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANBeatTracking.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/beat_f1"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANBeatTracking.Myna85M"
+      save_dir: "./output/probe.GTZANBeatTracking.Myna85M/"
+
+model:
+  class_path: marble.tasks.GTZANBeatTracking.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    fps: 25
+    use_ema: false
+    loss_weights: [1.0, 1.0, 0.0] # beat, downbeat, tempo (tempo disabled)
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 250
+          mode: nearest
+
+    decoders:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.BeatDownbeatTempoMultitaskDecoder
+        init_args:
+          fps: 25
+          use_ssl_for_tempo: false
+
+          joint_decoder:
+            class_path: marble.modules.decoders.MLPDecoderKeepTime
+            init_args:
+              in_dim: 1536
+              out_dim: 3 # beat, downbeat, tempo
+              hidden_layers: [512]
+              activation_fn:
+                class_path: torch.nn.ReLU
+              dropout: 0.2
+
+          tempo_decoder:
+            class_path: marble.tasks.GTZANBeatTracking.modules.FFTTempoEstimator
+            init_args:
+              label_fps: 25
+              freq_resolution: 4
+
+    losses:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # beat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # downbeat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: torch.nn.MSELoss # tempo
+        init_args:
+          reduction: mean
+
+    metrics:
+      val:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+      test:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+
+data:
+  class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANBeatTracking.train.jsonl
+        label_freq: 25
+        num_neighbors: 2
+    val:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.val.jsonl
+        label_freq: 25
+        num_neighbors: 0
+    test:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.test.jsonl
+        label_freq: 25
+        num_neighbors: 0
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/beat_f1"

--- a/configs/probe.Myna85M.GTZANGenre.yaml
+++ b/configs/probe.Myna85M.GTZANGenre.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANGenre.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANGenre.Myna85M"
+      save_dir: "./output/probe.GTZANGenre.Myna85M/"
+
+model:
+  class_path: marble.tasks.GTZANGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 10 # 10 genres
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+
+data:
+  class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANGenre.train.jsonl
+    val:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.val.jsonl
+    test:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 5e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/acc"

--- a/configs/probe.Myna85M.HookTheoryKey.yaml
+++ b/configs/probe.Myna85M.HookTheoryKey.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryKey.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryKey.Myna85M"
+      save_dir: "./output/probe.HookTheoryKey.Myna85M/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryKey.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.Myna85M.HookTheoryStructure.yaml
+++ b/configs/probe.Myna85M.HookTheoryStructure.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryStructure.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryStructure.Myna85M"
+      save_dir: "./output/probe.HookTheoryStructure.Myna85M/"
+
+model:
+  class_path: marble.tasks.HookTheoryStructure.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 7 # 7 structure classes
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+
+data:
+  class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryStructure.train.jsonl
+    val:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.val.jsonl
+    test:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.Myna85M.MTGGenre.yaml
+++ b/configs/probe.Myna85M.MTGGenre.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGGenre.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGGenre.Myna85M"
+      save_dir: "./output/probe.MTGGenre.Myna85M/"
+
+model:
+  class_path: marble.tasks.MTGGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 87
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGGenre.datamodule.MTGGenreDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.train.jsonl
+    val:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.val.jsonl
+    test:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.Myna85M.MTGInstrument.yaml
+++ b/configs/probe.Myna85M.MTGInstrument.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGInstrument.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGInstrument.Myna85M"
+      save_dir: "./output/probe.MTGInstrument.Myna85M/"
+
+model:
+  class_path: marble.tasks.MTGInstrument.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 40
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.train.jsonl
+    val:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.val.jsonl
+    test:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.Myna85M.MTGMood.yaml
+++ b/configs/probe.Myna85M.MTGMood.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGMood.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGMood.Myna85M"
+      save_dir: "./output/probe.MTGMood.Myna85M/"
+
+model:
+  class_path: marble.tasks.MTGMood.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 56
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGMood.datamodule.MTGMoodDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.train.jsonl
+    val:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.val.jsonl
+    test:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.Myna85M.MTGTop50.yaml
+++ b/configs/probe.Myna85M.MTGTop50.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGTop50.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGTop50.Myna85M"
+      save_dir: "./output/probe.MTGTop50.Myna85M/"
+
+model:
+  class_path: marble.tasks.MTGTop50.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGTop50.datamodule.MTGTop50DataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.train.jsonl
+    val:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.val.jsonl
+    test:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.Myna85M.MTT.yaml
+++ b/configs/probe.Myna85M.MTT.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTT.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTT.Myna85M"
+      save_dir: "./output/probe.MTT.Myna85M/"
+
+model:
+  class_path: marble.tasks.MTT.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTT.datamodule.MTTDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.train.jsonl
+    val:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.val.jsonl
+    test:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.Myna85M.MergeGSHT.yaml
+++ b/configs/probe.Myna85M.MergeGSHT.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MergeGSHT.Myna85M/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MergeGSHT.Myna85M"
+      save_dir: "./output/probe.MergeGSHT.Myna85M/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-85m
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 1536
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/MergeGSHT/MergeGSHT.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaBase.Chords1217.yaml
+++ b/configs/probe.MynaBase.Chords1217.yaml
@@ -1,0 +1,179 @@
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.Chords1217.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.Chords1217.MynaBase"
+      save_dir: "./output/probe.Chords1217.MynaBase/"
+
+model:
+  class_path: marble.tasks.Chords1217.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 375
+          mode: nearest
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoderKeepTime
+        init_args:
+          in_dim: 384
+          out_dim: 25
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: marble.tasks.Chords1217.probe.ChordCrossEntropyLoss
+        init_args:
+          time_dim_mismatch_tol: 5
+
+    metrics:
+      train:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      val:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      test:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+data:
+  class_path: marble.tasks.Chords1217.datamodule.Chords1217DataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/Chords1217/Chords1217.train.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    val:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.val.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    test:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.test.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.MynaBase.EMO.yaml
+++ b/configs/probe.MynaBase.EMO.yaml
@@ -1,0 +1,190 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.EMO.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/r2"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.EMO.MynaBase"
+      save_dir: "./output/probe.EMO.MynaBase/"
+
+model:
+  class_path: marble.tasks.EMO.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 2 # arousal, valence
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.MSELoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      val:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      test:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+
+data:
+  class_path: marble.tasks.EMO.datamodule.EMODataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/EMO/EMO.train.jsonl
+    val:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.val.jsonl
+    test:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/r2"

--- a/configs/probe.MynaBase.GS.yaml
+++ b/configs/probe.MynaBase.GS.yaml
@@ -1,0 +1,175 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GS.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GS.MynaBase"
+      save_dir: "./output/probe.GS.MynaBase/"
+
+model:
+  class_path: marble.tasks.GS.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 24 # 24 keys
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.GS.datamodule.GSDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GS.datamodule.GSAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GS/GS.train.jsonl
+    val:
+      class_path: marble.tasks.GS.datamodule.GSAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.val.jsonl
+    test:
+      class_path: marble.tasks.GS.datamodule.GSAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaBase.GTZANBeatTracking.yaml
+++ b/configs/probe.MynaBase.GTZANBeatTracking.yaml
@@ -1,0 +1,220 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANBeatTracking.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/beat_f1"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANBeatTracking.MynaBase"
+      save_dir: "./output/probe.GTZANBeatTracking.MynaBase/"
+
+model:
+  class_path: marble.tasks.GTZANBeatTracking.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    fps: 25
+    use_ema: false
+    loss_weights: [1.0, 1.0, 0.0] # beat, downbeat, tempo (tempo disabled)
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 250
+          mode: nearest
+
+    decoders:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.BeatDownbeatTempoMultitaskDecoder
+        init_args:
+          fps: 25
+          use_ssl_for_tempo: false
+
+          joint_decoder:
+            class_path: marble.modules.decoders.MLPDecoderKeepTime
+            init_args:
+              in_dim: 384
+              out_dim: 3 # beat, downbeat, tempo
+              hidden_layers: [512]
+              activation_fn:
+                class_path: torch.nn.ReLU
+              dropout: 0.2
+
+          tempo_decoder:
+            class_path: marble.tasks.GTZANBeatTracking.modules.FFTTempoEstimator
+            init_args:
+              label_fps: 25
+              freq_resolution: 4
+
+    losses:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # beat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # downbeat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: torch.nn.MSELoss # tempo
+        init_args:
+          reduction: mean
+
+    metrics:
+      val:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+      test:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+
+data:
+  class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANBeatTracking.train.jsonl
+        label_freq: 25
+        num_neighbors: 2
+    val:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.val.jsonl
+        label_freq: 25
+        num_neighbors: 0
+    test:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.test.jsonl
+        label_freq: 25
+        num_neighbors: 0
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/beat_f1"

--- a/configs/probe.MynaBase.GTZANGenre.yaml
+++ b/configs/probe.MynaBase.GTZANGenre.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANGenre.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANGenre.MynaBase"
+      save_dir: "./output/probe.GTZANGenre.MynaBase/"
+
+model:
+  class_path: marble.tasks.GTZANGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 10 # 10 genres
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+
+data:
+  class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANGenre.train.jsonl
+    val:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.val.jsonl
+    test:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 5e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/acc"

--- a/configs/probe.MynaBase.HookTheoryKey.yaml
+++ b/configs/probe.MynaBase.HookTheoryKey.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryKey.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryKey.MynaBase"
+      save_dir: "./output/probe.HookTheoryKey.MynaBase/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryKey.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaBase.HookTheoryStructure.yaml
+++ b/configs/probe.MynaBase.HookTheoryStructure.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryStructure.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryStructure.MynaBase"
+      save_dir: "./output/probe.HookTheoryStructure.MynaBase/"
+
+model:
+  class_path: marble.tasks.HookTheoryStructure.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 7 # 7 structure classes
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+
+data:
+  class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryStructure.train.jsonl
+    val:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.val.jsonl
+    test:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.MynaBase.MTGGenre.yaml
+++ b/configs/probe.MynaBase.MTGGenre.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGGenre.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGGenre.MynaBase"
+      save_dir: "./output/probe.MTGGenre.MynaBase/"
+
+model:
+  class_path: marble.tasks.MTGGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 87
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGGenre.datamodule.MTGGenreDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.train.jsonl
+    val:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.val.jsonl
+    test:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaBase.MTGInstrument.yaml
+++ b/configs/probe.MynaBase.MTGInstrument.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGInstrument.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGInstrument.MynaBase"
+      save_dir: "./output/probe.MTGInstrument.MynaBase/"
+
+model:
+  class_path: marble.tasks.MTGInstrument.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 40
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.train.jsonl
+    val:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.val.jsonl
+    test:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaBase.MTGMood.yaml
+++ b/configs/probe.MynaBase.MTGMood.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGMood.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGMood.MynaBase"
+      save_dir: "./output/probe.MTGMood.MynaBase/"
+
+model:
+  class_path: marble.tasks.MTGMood.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 56
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGMood.datamodule.MTGMoodDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.train.jsonl
+    val:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.val.jsonl
+    test:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaBase.MTGTop50.yaml
+++ b/configs/probe.MynaBase.MTGTop50.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGTop50.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGTop50.MynaBase"
+      save_dir: "./output/probe.MTGTop50.MynaBase/"
+
+model:
+  class_path: marble.tasks.MTGTop50.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGTop50.datamodule.MTGTop50DataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.train.jsonl
+    val:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.val.jsonl
+    test:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaBase.MTT.yaml
+++ b/configs/probe.MynaBase.MTT.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTT.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTT.MynaBase"
+      save_dir: "./output/probe.MTT.MynaBase/"
+
+model:
+  class_path: marble.tasks.MTT.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTT.datamodule.MTTDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.train.jsonl
+    val:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.val.jsonl
+    test:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaBase.MergeGSHT.yaml
+++ b/configs/probe.MynaBase.MergeGSHT.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MergeGSHT.MynaBase/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MergeGSHT.MynaBase"
+      save_dir: "./output/probe.MergeGSHT.MynaBase/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-base
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/MergeGSHT/MergeGSHT.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaHybrid.Chords1217.yaml
+++ b/configs/probe.MynaHybrid.Chords1217.yaml
@@ -1,0 +1,179 @@
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.Chords1217.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.Chords1217.MynaHybrid"
+      save_dir: "./output/probe.Chords1217.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.Chords1217.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 375
+          mode: nearest
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoderKeepTime
+        init_args:
+          in_dim: 768
+          out_dim: 25
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: marble.tasks.Chords1217.probe.ChordCrossEntropyLoss
+        init_args:
+          time_dim_mismatch_tol: 5
+
+    metrics:
+      train:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      val:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      test:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+data:
+  class_path: marble.tasks.Chords1217.datamodule.Chords1217DataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/Chords1217/Chords1217.train.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    val:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.val.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    test:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.test.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.MynaHybrid.EMO.yaml
+++ b/configs/probe.MynaHybrid.EMO.yaml
@@ -1,0 +1,190 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.EMO.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/r2"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.EMO.MynaHybrid"
+      save_dir: "./output/probe.EMO.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.EMO.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 2 # arousal, valence
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.MSELoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      val:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      test:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+
+data:
+  class_path: marble.tasks.EMO.datamodule.EMODataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/EMO/EMO.train.jsonl
+    val:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.val.jsonl
+    test:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/r2"

--- a/configs/probe.MynaHybrid.GS.yaml
+++ b/configs/probe.MynaHybrid.GS.yaml
@@ -1,0 +1,175 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GS.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GS.MynaHybrid"
+      save_dir: "./output/probe.GS.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.GS.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 24 # 24 keys
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.GS.datamodule.GSDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GS.datamodule.GSAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GS/GS.train.jsonl
+    val:
+      class_path: marble.tasks.GS.datamodule.GSAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.val.jsonl
+    test:
+      class_path: marble.tasks.GS.datamodule.GSAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaHybrid.GTZANBeatTracking.yaml
+++ b/configs/probe.MynaHybrid.GTZANBeatTracking.yaml
@@ -1,0 +1,220 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANBeatTracking.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/beat_f1"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANBeatTracking.MynaHybrid"
+      save_dir: "./output/probe.GTZANBeatTracking.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.GTZANBeatTracking.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    fps: 25
+    use_ema: false
+    loss_weights: [1.0, 1.0, 0.0] # beat, downbeat, tempo (tempo disabled)
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 250
+          mode: nearest
+
+    decoders:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.BeatDownbeatTempoMultitaskDecoder
+        init_args:
+          fps: 25
+          use_ssl_for_tempo: false
+
+          joint_decoder:
+            class_path: marble.modules.decoders.MLPDecoderKeepTime
+            init_args:
+              in_dim: 768
+              out_dim: 3 # beat, downbeat, tempo
+              hidden_layers: [512]
+              activation_fn:
+                class_path: torch.nn.ReLU
+              dropout: 0.2
+
+          tempo_decoder:
+            class_path: marble.tasks.GTZANBeatTracking.modules.FFTTempoEstimator
+            init_args:
+              label_fps: 25
+              freq_resolution: 4
+
+    losses:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # beat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # downbeat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: torch.nn.MSELoss # tempo
+        init_args:
+          reduction: mean
+
+    metrics:
+      val:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+      test:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+
+data:
+  class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANBeatTracking.train.jsonl
+        label_freq: 25
+        num_neighbors: 2
+    val:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.val.jsonl
+        label_freq: 25
+        num_neighbors: 0
+    test:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.test.jsonl
+        label_freq: 25
+        num_neighbors: 0
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/beat_f1"

--- a/configs/probe.MynaHybrid.GTZANGenre.yaml
+++ b/configs/probe.MynaHybrid.GTZANGenre.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANGenre.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANGenre.MynaHybrid"
+      save_dir: "./output/probe.GTZANGenre.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.GTZANGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 10 # 10 genres
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+
+data:
+  class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANGenre.train.jsonl
+    val:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.val.jsonl
+    test:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 5e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/acc"

--- a/configs/probe.MynaHybrid.HookTheoryKey.yaml
+++ b/configs/probe.MynaHybrid.HookTheoryKey.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryKey.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryKey.MynaHybrid"
+      save_dir: "./output/probe.HookTheoryKey.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryKey.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaHybrid.HookTheoryStructure.yaml
+++ b/configs/probe.MynaHybrid.HookTheoryStructure.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryStructure.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryStructure.MynaHybrid"
+      save_dir: "./output/probe.HookTheoryStructure.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.HookTheoryStructure.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 7 # 7 structure classes
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+
+data:
+  class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryStructure.train.jsonl
+    val:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.val.jsonl
+    test:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.MynaHybrid.MTGGenre.yaml
+++ b/configs/probe.MynaHybrid.MTGGenre.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGGenre.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGGenre.MynaHybrid"
+      save_dir: "./output/probe.MTGGenre.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.MTGGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 87
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGGenre.datamodule.MTGGenreDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.train.jsonl
+    val:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.val.jsonl
+    test:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaHybrid.MTGInstrument.yaml
+++ b/configs/probe.MynaHybrid.MTGInstrument.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGInstrument.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGInstrument.MynaHybrid"
+      save_dir: "./output/probe.MTGInstrument.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.MTGInstrument.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 40
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.train.jsonl
+    val:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.val.jsonl
+    test:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaHybrid.MTGMood.yaml
+++ b/configs/probe.MynaHybrid.MTGMood.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGMood.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGMood.MynaHybrid"
+      save_dir: "./output/probe.MTGMood.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.MTGMood.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 56
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGMood.datamodule.MTGMoodDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.train.jsonl
+    val:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.val.jsonl
+    test:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaHybrid.MTGTop50.yaml
+++ b/configs/probe.MynaHybrid.MTGTop50.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGTop50.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGTop50.MynaHybrid"
+      save_dir: "./output/probe.MTGTop50.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.MTGTop50.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGTop50.datamodule.MTGTop50DataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.train.jsonl
+    val:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.val.jsonl
+    test:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaHybrid.MTT.yaml
+++ b/configs/probe.MynaHybrid.MTT.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTT.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTT.MynaHybrid"
+      save_dir: "./output/probe.MTT.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.MTT.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTT.datamodule.MTTDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.train.jsonl
+    val:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.val.jsonl
+    test:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaHybrid.MergeGSHT.yaml
+++ b/configs/probe.MynaHybrid.MergeGSHT.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MergeGSHT.MynaHybrid/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MergeGSHT.MynaHybrid"
+      save_dir: "./output/probe.MergeGSHT.MynaHybrid/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-hybrid
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 768
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/MergeGSHT/MergeGSHT.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaVertical.Chords1217.yaml
+++ b/configs/probe.MynaVertical.Chords1217.yaml
@@ -1,0 +1,179 @@
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.Chords1217.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.Chords1217.MynaVertical"
+      save_dir: "./output/probe.Chords1217.MynaVertical/"
+
+model:
+  class_path: marble.tasks.Chords1217.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 375
+          mode: nearest
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoderKeepTime
+        init_args:
+          in_dim: 384
+          out_dim: 25
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: marble.tasks.Chords1217.probe.ChordCrossEntropyLoss
+        init_args:
+          time_dim_mismatch_tol: 5
+
+    metrics:
+      train:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      val:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+      test:
+        acc:
+          class_path: marble.tasks.Chords1217.probe.ChordAccuracy
+          init_args:
+            time_dim_mismatch_tol: 5
+            ignore_index: -1 # ignore the non maj min chords
+
+data:
+  class_path: marble.tasks.Chords1217.datamodule.Chords1217DataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/Chords1217/Chords1217.train.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    val:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.val.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+    test:
+      class_path: marble.tasks.Chords1217.datamodule.Chords1217AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/Chords1217/Chords1217.test.jsonl
+        label_freq: 25
+        backend: "soundfile" # speed up random read flac
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.MynaVertical.EMO.yaml
+++ b/configs/probe.MynaVertical.EMO.yaml
@@ -1,0 +1,190 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.EMO.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/r2"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.EMO.MynaVertical"
+      save_dir: "./output/probe.EMO.MynaVertical/"
+
+model:
+  class_path: marble.tasks.EMO.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 2 # arousal, valence
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.MSELoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      val:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+      test:
+        r2:
+          class_path: torchmetrics.R2Score
+          init_args:
+            multioutput: uniform_average
+        arousal_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 0
+        valence_r2:
+          class_path: marble.tasks.EMO.probe.SliceR2
+          init_args:
+            dim: 1
+
+data:
+  class_path: marble.tasks.EMO.datamodule.EMODataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/EMO/EMO.train.jsonl
+    val:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.val.jsonl
+    test:
+      class_path: marble.tasks.EMO.datamodule.EMOAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/EMO/EMO.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/r2"

--- a/configs/probe.MynaVertical.GS.yaml
+++ b/configs/probe.MynaVertical.GS.yaml
@@ -1,0 +1,175 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GS.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GS.MynaVertical"
+      save_dir: "./output/probe.GS.MynaVertical/"
+
+model:
+  class_path: marble.tasks.GS.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 24 # 24 keys
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.GS.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.GS.datamodule.GSDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GS.datamodule.GSAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GS/GS.train.jsonl
+    val:
+      class_path: marble.tasks.GS.datamodule.GSAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.val.jsonl
+    test:
+      class_path: marble.tasks.GS.datamodule.GSAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GS/GS.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaVertical.GTZANBeatTracking.yaml
+++ b/configs/probe.MynaVertical.GTZANBeatTracking.yaml
@@ -1,0 +1,220 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANBeatTracking.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/beat_f1"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANBeatTracking.MynaVertical"
+      save_dir: "./output/probe.GTZANBeatTracking.MynaVertical/"
+
+model:
+  class_path: marble.tasks.GTZANBeatTracking.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    fps: 25
+    use_ema: false
+    loss_weights: [1.0, 1.0, 0.0] # beat, downbeat, tempo (tempo disabled)
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeInterpolation
+        init_args:
+          target_frames: 250
+          mode: nearest
+
+    decoders:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.BeatDownbeatTempoMultitaskDecoder
+        init_args:
+          fps: 25
+          use_ssl_for_tempo: false
+
+          joint_decoder:
+            class_path: marble.modules.decoders.MLPDecoderKeepTime
+            init_args:
+              in_dim: 384
+              out_dim: 3 # beat, downbeat, tempo
+              hidden_layers: [512]
+              activation_fn:
+                class_path: torch.nn.ReLU
+              dropout: 0.2
+
+          tempo_decoder:
+            class_path: marble.tasks.GTZANBeatTracking.modules.FFTTempoEstimator
+            init_args:
+              label_fps: 25
+              freq_resolution: 4
+
+    losses:
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # beat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: marble.tasks.GTZANBeatTracking.probe.CustomBCEWithLogitsLoss # downbeat
+        init_args:
+          pos_weight: null
+          time_dim_mismatch_tol: 5
+      - class_path: torch.nn.MSELoss # tempo
+        init_args:
+          reduction: mean
+
+    metrics:
+      val:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+      test:
+        beat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        downbeat_f1:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TimeEventFMeasure
+          init_args:
+            label_freq: 25
+            tol: 0.07
+            threshold: 0.99
+        tempo_mae:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoMAE
+        tempo_acc:
+          class_path: marble.tasks.GTZANBeatTracking.metrics.TempoAccuracy
+          init_args:
+            tol: 0.04
+
+data:
+  class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANBeatTracking.train.jsonl
+        label_freq: 25
+        num_neighbors: 2
+    val:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.val.jsonl
+        label_freq: 25
+        num_neighbors: 0
+    test:
+      class_path: marble.tasks.GTZANBeatTracking.datamodule.GTZANBeatTrackingAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 10
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANBeatTracking.test.jsonl
+        label_freq: 25
+        num_neighbors: 0
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/beat_f1"

--- a/configs/probe.MynaVertical.GTZANGenre.yaml
+++ b/configs/probe.MynaVertical.GTZANGenre.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 100
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.GTZANGenre.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 20                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.GTZANGenre.MynaVertical"
+      save_dir: "./output/probe.GTZANGenre.MynaVertical/"
+
+model:
+  class_path: marble.tasks.GTZANGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 10 # 10 genres
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 10
+            task: multiclass
+
+data:
+  class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 8
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: first # first, random, mix
+        jsonl: data/GTZAN/GTZANGenre.train.jsonl
+    val:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.val.jsonl
+    test:
+      class_path: marble.tasks.GTZANGenre.datamodule.GTZANGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30.2
+        min_clip_ratio: 0.8
+        channel_mode: first
+        jsonl: data/GTZAN/GTZANGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 5e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 6
+    monitor: "val/acc"

--- a/configs/probe.MynaVertical.HookTheoryKey.yaml
+++ b/configs/probe.MynaVertical.HookTheoryKey.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryKey.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryKey.MynaVertical"
+      save_dir: "./output/probe.HookTheoryKey.MynaVertical/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryKey.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryKey.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/configs/probe.MynaVertical.HookTheoryStructure.yaml
+++ b/configs/probe.MynaVertical.HookTheoryStructure.yaml
@@ -1,0 +1,169 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.HookTheoryStructure.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/acc"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.HookTheoryStructure.MynaVertical"
+      save_dir: "./output/probe.HookTheoryStructure.MynaVertical/"
+
+model:
+  class_path: marble.tasks.HookTheoryStructure.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 7 # 7 structure classes
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 7
+            task: multiclass
+
+data:
+  class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureDataModule
+  init_args:
+    batch_size: 16
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1 # at least 10% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/HookTheory/HookTheoryStructure.train.jsonl
+    val:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.val.jsonl
+    test:
+      class_path: marble.tasks.HookTheoryStructure.datamodule.HookTheoryStructureAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.1
+        channel_mode: mix
+        jsonl: data/HookTheory/HookTheoryStructure.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/acc"

--- a/configs/probe.MynaVertical.MTGGenre.yaml
+++ b/configs/probe.MynaVertical.MTGGenre.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGGenre.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGGenre.MynaVertical"
+      save_dir: "./output/probe.MTGGenre.MynaVertical/"
+
+model:
+  class_path: marble.tasks.MTGGenre.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 87
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 87
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGGenre.datamodule.MTGGenreDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.train.jsonl
+    val:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.val.jsonl
+    test:
+      class_path: marble.tasks.MTGGenre.datamodule.MTGGenreAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGGenre.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaVertical.MTGInstrument.yaml
+++ b/configs/probe.MynaVertical.MTGInstrument.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGInstrument.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGInstrument.MynaVertical"
+      save_dir: "./output/probe.MTGInstrument.MynaVertical/"
+
+model:
+  class_path: marble.tasks.MTGInstrument.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 40
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 40
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.train.jsonl
+    val:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.val.jsonl
+    test:
+      class_path: marble.tasks.MTGInstrument.datamodule.MTGInstrumentAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGInstrument.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaVertical.MTGMood.yaml
+++ b/configs/probe.MynaVertical.MTGMood.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGMood.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGMood.MynaVertical"
+      save_dir: "./output/probe.MTGMood.MynaVertical/"
+
+model:
+  class_path: marble.tasks.MTGMood.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 56
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 56
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGMood.datamodule.MTGMoodDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.train.jsonl
+    val:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.val.jsonl
+    test:
+      class_path: marble.tasks.MTGMood.datamodule.MTGMoodAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGMood.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaVertical.MTGTop50.yaml
+++ b/configs/probe.MynaVertical.MTGTop50.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTGTop50.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTGTop50.MynaVertical"
+      save_dir: "./output/probe.MTGTop50.MynaVertical/"
+
+model:
+  class_path: marble.tasks.MTGTop50.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTGTop50.datamodule.MTGTop50DataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.train.jsonl
+    val:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.val.jsonl
+    test:
+      class_path: marble.tasks.MTGTop50.datamodule.MTGTop50AudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTG/MTGTop50.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaVertical.MTT.yaml
+++ b/configs/probe.MynaVertical.MTT.yaml
@@ -1,0 +1,216 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 4
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 20
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 5
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MTT.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/auroc"               # 要监控的 metric 名称
+        check_on_train_epoch_end: false
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MTT.MynaVertical"
+      save_dir: "./output/probe.MTT.MynaVertical/"
+
+model:
+  class_path: marble.tasks.MTT.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 50
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.BCEWithLogitsLoss
+
+    metrics:
+      train:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      val:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+      test:
+        f1:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        f1_micro:
+          class_path: torchmetrics.F1Score
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: micro
+        auroc:
+          class_path: torchmetrics.AUROC
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+        ap:
+          class_path: torchmetrics.AveragePrecision
+          init_args:
+            task: multilabel
+            num_labels: 50
+            average: macro
+
+data:
+  class_path: marble.tasks.MTT.datamodule.MTTDataModule
+  init_args:
+    batch_size: 32
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: mix # first, random, mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.train.jsonl
+    val:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.val.jsonl
+    test:
+      class_path: marble.tasks.MTT.datamodule.MTTAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 30
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        backend: "soundfile" # or "sox_io"
+        jsonl: data/MTT/MTT.test.jsonl
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.5
+    patience: 5
+    monitor: "val/auroc"

--- a/configs/probe.MynaVertical.MergeGSHT.yaml
+++ b/configs/probe.MynaVertical.MergeGSHT.yaml
@@ -1,0 +1,178 @@
+seed_everything: 1234
+ckpt_path: null # to resume
+
+trainer:
+  fast_dev_run: false
+  accelerator: gpu
+  # strategy: ddp # or ddp_find_unused_parameters
+  devices: [0]
+  accumulate_grad_batches: 8
+  num_nodes: 1
+  precision: bf16 # or 32, or 16
+  max_epochs: 50
+  check_val_every_n_epoch: 1
+  num_sanity_val_steps: 10
+  log_every_n_steps: 50
+
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        dirpath: "./output/probe.MergeGSHT.MynaVertical/checkpoints/" # Please specify your own path
+        filename: "best"
+        save_top_k: 1 # -1 to save all checkpoints
+    - class_path: marble.modules.callbacks.LoadLatestCheckpointCallback # for testing
+    - class_path: lightning.pytorch.callbacks.LearningRateMonitor
+      init_args:
+        logging_interval: step
+    - class_path: lightning.pytorch.callbacks.early_stopping.EarlyStopping
+      init_args:
+        monitor: "val/weighted_score"               # 要监控的 metric 名称
+        patience: 10                       # 在多少次验证后无改进就停止
+        mode: "max"                       # “val_loss” 下降时才算改进
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+    init_args:
+      project: "marble"
+      name: "probe.MergeGSHT.MynaVertical"
+      save_dir: "./output/probe.MergeGSHT.MynaVertical/"
+
+model:
+  class_path: marble.tasks.HookTheoryKey.probe.ProbeAudioTask
+  init_args:
+    sample_rate: 16000
+    use_ema: false
+
+    encoder:
+      class_path: marble.encoders.Myna.model.MynaEncoder
+      init_args:
+        model_name: oriyonay/myna-vertical
+        train_mode: freeze  # also supports full
+
+    emb_transforms:
+      - class_path: marble.modules.transforms.TimeAvgPool # (batch_size, num_layers, 1, hidden_size)
+
+    decoders:
+      - class_path: marble.modules.decoders.MLPDecoder
+        init_args:
+          in_dim: 384
+          out_dim: 24 # 24 KEYS
+          hidden_layers: [512]
+          activation_fn:
+            class_path: torch.nn.ReLU
+          dropout: 0.2
+
+    losses:
+      - class_path: torch.nn.CrossEntropyLoss
+        init_args:
+          reduction: mean
+
+    metrics:
+      train:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      val:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+      test:
+        acc:
+          class_path: torchmetrics.Accuracy
+          init_args:
+            num_classes: 24
+            task: multiclass
+        weighted_score:
+          class_path: marble.tasks.HookTheoryKey.probe.KeyWeightedScore
+
+data:
+  class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyDataModule
+  init_args:
+    batch_size: 8
+    num_workers: 16
+
+    audio_transforms:
+      train:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      val:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+      test:
+        - class_path: marble.modules.transforms.MelSpectrogram
+          init_args:
+            sample_rate: 16000
+            n_fft: 1024
+            win_length: 1024
+            hop_length: 256
+            n_mels: 128
+        - class_path: marble.modules.transforms.PadToMultiple
+          init_args:
+            multiple: 16
+
+    train:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTrain
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8 # at least 80% of the clip length
+        channel_mode: random # first, random, mix
+        jsonl: data/MergeGSHT/MergeGSHT.train.jsonl
+        maj_minor_only: true # only use major and minor keys
+    val:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioVal
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.val.jsonl
+        maj_minor_only: true # only use major and minor keys
+    test:
+      class_path: marble.tasks.HookTheoryKey.datamodule.HookTheoryKeyAudioTest
+      init_args:
+        sample_rate: 16000
+        channels: 1
+        clip_seconds: 15
+        min_clip_ratio: 0.8
+        channel_mode: mix
+        jsonl: data/MergeGSHT/MergeGSHT.test.jsonl
+        maj_minor_only: true # only use major and minor keys
+
+optimizer:
+  class_path: torch.optim.Adam
+  init_args:
+    lr: 1e-3
+
+lr_scheduler:
+  class_path: lightning.pytorch.cli.ReduceLROnPlateau
+  init_args:
+    mode: "max"
+    factor: 0.1
+    patience: 5
+    monitor: "val/weighted_score"

--- a/marble/encoders/Myna/__init__.py
+++ b/marble/encoders/Myna/__init__.py
@@ -1,0 +1,5 @@
+"""Myna encoder wrapper."""
+
+from .model import MynaEncoder
+
+__all__ = ["MynaEncoder"]

--- a/marble/encoders/Myna/model.py
+++ b/marble/encoders/Myna/model.py
@@ -1,0 +1,91 @@
+"""Lightweight wrapper for the Hugging Face Myna checkpoints."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import torch
+from transformers import AutoModel
+
+from marble.core.base_encoder import BaseEncoder
+
+
+def _resolve_model_name(name: str, aliases: Dict[str, str]) -> str:
+    """Resolve short aliases like ``"myna-hybrid"`` to full repo IDs."""
+
+    return aliases.get(name.lower(), name)
+
+
+class MynaEncoder(BaseEncoder):
+    """Thin wrapper around :func:`transformers.AutoModel.from_pretrained`."""
+
+    MODEL_ALIASES: Dict[str, str] = {
+        "myna-hybrid": "oriyonay/myna-hybrid",
+        "myna-base": "oriyonay/myna-base",
+        "myna-vertical": "oriyonay/myna-vertical",
+        "myna-85m": "oriyonay/myna-85m",
+    }
+
+    MODEL_DIMENSIONS: Dict[str, int] = {
+        "oriyonay/myna-hybrid": 768,
+        "oriyonay/myna-base": 384,
+        "oriyonay/myna-vertical": 384,
+        "oriyonay/myna-85m": 1536,
+    }
+
+    def __init__(
+        self,
+        model_name: str = "oriyonay/myna-hybrid",
+        *,
+        pre_trained_folder: Optional[str] = None,
+        train_mode: str = "freeze",
+        trust_remote_code: bool = True,
+    ) -> None:
+        super().__init__()
+
+        repo = pre_trained_folder or _resolve_model_name(model_name, self.MODEL_ALIASES)
+        self.model = AutoModel.from_pretrained(repo, trust_remote_code=trust_remote_code)
+
+        if train_mode not in {"freeze", "full"}:
+            raise ValueError("train_mode must be either 'freeze' or 'full'.")
+
+        requires_grad = train_mode == "full"
+        for param in self.model.parameters():
+            param.requires_grad = requires_grad
+
+        self.model.train(mode=requires_grad)
+
+        self.embedding_dim = self.MODEL_DIMENSIONS.get(repo, 0)
+
+    def forward(self, input_tensor: torch.Tensor, input_len: Optional[torch.Tensor] = None) -> torch.Tensor:
+        del input_len
+
+        params = next(self.model.parameters())
+        device = params.device
+        dtype = params.dtype
+
+        outputs = self.model(input_tensor.to(device=device, dtype=dtype))
+
+        if isinstance(outputs, torch.Tensor):
+            embeddings = outputs
+        else:
+            # Some subclasses may wrap the tensor in a dataclass, but Myna does not
+            raise TypeError(
+                "Unexpected output type from Myna model; expected torch.Tensor but "
+                f"received {type(outputs)!r}."
+            )
+
+        if embeddings.ndim == 1:
+            embeddings = embeddings.unsqueeze(0)
+        if embeddings.ndim == 2:
+            embeddings = embeddings.unsqueeze(1)
+        if embeddings.ndim == 3:
+            embeddings = embeddings.unsqueeze(1)
+
+        if embeddings.ndim != 4:
+            raise ValueError(
+                "Myna encoder outputs must be a 4D tensor of shape [batch, layers, time, "
+                f"hidden], but received {embeddings.shape}."
+            )
+
+        return embeddings

--- a/marble/modules/transforms.py
+++ b/marble/modules/transforms.py
@@ -209,6 +209,35 @@ class MelSpectrogram(BaseAudioTransform):
         return sample
 
 
+class PadToMultiple(BaseAudioTransform):
+    """Pad the last dimension so its length is a multiple of ``multiple``."""
+
+    def __init__(self, multiple: int) -> None:
+        super().__init__()
+        if multiple <= 0:
+            raise ValueError("multiple must be a positive integer")
+        self.multiple = multiple
+
+    def forward(self, sample: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        x = sample["input_features"]
+        if not isinstance(x, torch.Tensor):
+            raise TypeError("PadToMultiple expects a torch.Tensor input")
+
+        length = x.shape[-1]
+        if length == 0:
+            target = self.multiple
+        else:
+            target = ((length + self.multiple - 1) // self.multiple) * self.multiple
+
+        if length == target:
+            return sample
+
+        pad_amount = target - length
+
+        sample["input_features"] = F.pad(x, (0, pad_amount))
+        return sample
+
+
 ############################## Embedding Transforms ##############################
 
 


### PR DESCRIPTION
## Summary
- ensure the Myna encoder always emits 4D [batch, layer, time, hidden] tensors for downstream decoders
- add a PadToMultiple audio transform to make mel spectra patch-aligned for Myna
- author YAML experiment configs covering all MARBLE probe tasks for the Myna Hybrid, Base, Vertical, and 85M checkpoints

## Testing
- python -m compileall marble/encoders/Myna/model.py marble/modules/transforms.py